### PR TITLE
Fix #11 Gulp CSS autoprefixer

### DIFF
--- a/config.js.sample
+++ b/config.js.sample
@@ -21,7 +21,7 @@ module.exports = {
             googleplus: 'https://plus.google.com/u/0/100500349692608932832/posts'
         },
         github: {
-            url: 'http://tilap.github.com/frast/'
+            url: 'http://github.com/tilap/frast/'
         }
     },
     server: {
@@ -83,6 +83,14 @@ module.exports = {
                     paths: ['vendor']
                 }
             },
+            autoprefixer : {
+                enabled : true,
+                // See https://github.com/sindresorhus/gulp-autoprefixer
+                options: {
+                    browsers: ['last 2 versions'],
+                    cascade: false
+                }
+            }
         },
         // see https://github.com/twolfson/gulp.spritesmith#documentation
         // Path for sources, templates and so on are defined in .paths.sprites

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,6 +107,16 @@ gulp.task('less', function() {
                     this.emit('end');
                 })
         )
+        // Autoprefixer
+        .pipe( $.if(
+            config.style.compilation.autoprefixer.enabled,
+            $.autoprefixer(config.style.compilation.autoprefixer.options)
+            .on('error', function(err) {
+                notifyUser('Style', 'Autoprefixer failed');
+                logger.error('autoprefixer error: ' + err.message, null, 'gulp less');
+                this.emit('end');
+            })
+        ) )
         // Move to dist
         .pipe(gulp.dest(config.paths.less.tmp));
 });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mkdirp": "0.5.x",
     "node-human-logger": "git://github.com/tilap/node-human-logger#v0.1.0",
     "node-notifier": "3.1.x",
-    "tiny-lr": "0.1.x"
+    "tiny-lr": "0.1.x",
+    "gulp-autoprefixer": "^2.0.0"
   }
 }


### PR DESCRIPTION
Add optionnal gulp css vendor autoprefier.
Can be enablled/disabled and customized via the config file
