### PR TITLE
fix #14 : Enable export via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ clean:
 	$(BIN)/gulp clean
 	rm -Rf node_modules vendor tmp
 
+export:
+	$(BIN)/gulp clean
+	$(BIN)/gulp build
+	$(BIN)/gulp export
+    
 
 ##################################
 # Fonts stuff

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -363,12 +363,12 @@ gulp.task('export', function() {
                 version = require('./package.json').version || '0',
 
                 today = new Date(),
-                dateStr =
-                    today.getFullYear() +
-                    (today.getMonth()+1 < 10 ? '0' + today.getMonth()+1 : today.getMonth()+1) +
+                dateStr = '' + 
+                    today.getFullYear() + '' +
+                    (today.getMonth()+1 < 10 ? '0' + today.getMonth()+1 : today.getMonth()+1) + '' +
                     (today.getDate() < 10 ? '0' + today.getDate() : today.getDate()) + '-' +
-                    (today.getHours() < 10 ? '0' + today.getHours() : today.getHours()) +
-                    (today.getMinutes() < 10 ? '0' + today.getMinutes() : today.getMinutes()) +
+                    (today.getHours() < 10 ? '0' + today.getHours() : today.getHours()) + '' +
+                    (today.getMinutes() < 10 ? '0' + today.getMinutes() : today.getMinutes()) + '' +
                     (today.getSeconds() < 10 ? '0' + today.getSeconds() : today.getSeconds());
 
             mkdirp(folder , function (err) {


### PR DESCRIPTION
- Add `make export` cmd that will clean up, rebuild dist files and put them in a tarball with optionnaly a place to export to.
- Fix the file naming problem (number addition instead of concat)
